### PR TITLE
Enable driver to work on OCP 4.4 and OCP 4.5

### DIFF
--- a/helm/os-vim-driver/templates/deployment.yaml
+++ b/helm/os-vim-driver/templates/deployment.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: os-vim-driver
 spec:
   replicas: {{ .Values.app.replicas }}
+  selector:
+    matchLabels:
+      app: os-vim-driver
   template:
     metadata:
       labels:


### PR DESCRIPTION
*issue:* #62 
Changes:
modifications in deployment.yaml to enable the OS VIM driver to install on an OCP 4.4+ system by updating API version
