### PR TITLE
Error Messages not clear for Adopting suspended stacks - Issue #69

### DIFF
--- a/osvimdriver/service/resourcedriver.py
+++ b/osvimdriver/service/resourcedriver.py
@@ -351,6 +351,8 @@ class ResourceDriverHandler(Service, ResourceDriverHandlerCapability):
             status = self.__determine_delete_status(request_id, stack_id, stack_status)
         if status == STATUS_FAILED:
             description = stack.get('stack_status_reason', None)
+            if request_type == ADOPT_REQUEST_PREFIX:
+                description = "Adopt Failed. Stack Status: "+stack.get('stack_status', None)+" Reason: "+stack.get('stack_status_reason', None)
             failure_details = FailureDetails(FAILURE_CODE_INFRASTRUCTURE_ERROR, description)
             status_reason = stack.get('stack_status_reason', None)
         outputs = None

--- a/osvimdriver/service/resourcedriver.py
+++ b/osvimdriver/service/resourcedriver.py
@@ -352,7 +352,7 @@ class ResourceDriverHandler(Service, ResourceDriverHandlerCapability):
         if status == STATUS_FAILED:
             description = stack.get('stack_status_reason', None)
             if request_type == ADOPT_REQUEST_PREFIX:
-                description = "Adopt Failed. Stack Status: "+stack.get('stack_status', None)+" Reason: "+stack.get('stack_status_reason', None)
+                description = "Adopt failed: cannot adopt stack with status "+stack.get('stack_status', None)
             failure_details = FailureDetails(FAILURE_CODE_INFRASTRUCTURE_ERROR, description)
             status_reason = stack.get('stack_status_reason', None)
         outputs = None

--- a/tests/unit/service/test_resourcedriver.py
+++ b/tests/unit/service/test_resourcedriver.py
@@ -454,7 +454,7 @@ class TestResourceDriverHandler(unittest.TestCase):
         self.assertIsInstance(execution, LifecycleExecution)
         self.assertEqual(execution.request_id, 'Adopt::1::request123')
         self.assertEqual(execution.status, 'FAILED')        
-        self.assertEqual(str(execution.failure_details), 'failure_code: INFRASTRUCTURE_ERROR description: SUSPEND_COMPLETE')
+        self.assertEqual(str(execution.failure_details), 'failure_code: INFRASTRUCTURE_ERROR description: Adopt Failed. Stack Status: SUSPEND_COMPLETE Reason: SUSPEND_COMPLETE')
 
     def test_get_lifecycle_execution_adopt_skip_status_check(self):
         # here we generate a stack status of suspended, but will still import, becuase the skip status check will be set
@@ -556,7 +556,7 @@ class TestResourceDriverHandler(unittest.TestCase):
         self.assertEqual(execution.request_id, 'Adopt::1::request123')
         self.assertEqual(execution.status, 'FAILED')
         self.assertEqual(execution.failure_details.failure_code, 'INFRASTRUCTURE_ERROR')
-        self.assertEqual(execution.failure_details.description, 'For the test')
+        self.assertEqual(execution.failure_details.description, 'Adopt Failed. Stack Status: ADOPT_FAILED Reason: For the test')
         self.assertEqual(execution.outputs, None)
         self.assertEqual(execution.associated_topology, None)
 

--- a/tests/unit/service/test_resourcedriver.py
+++ b/tests/unit/service/test_resourcedriver.py
@@ -454,7 +454,7 @@ class TestResourceDriverHandler(unittest.TestCase):
         self.assertIsInstance(execution, LifecycleExecution)
         self.assertEqual(execution.request_id, 'Adopt::1::request123')
         self.assertEqual(execution.status, 'FAILED')        
-        self.assertEqual(str(execution.failure_details), 'failure_code: INFRASTRUCTURE_ERROR description: Adopt Failed. Stack Status: SUSPEND_COMPLETE Reason: SUSPEND_COMPLETE')
+        self.assertEqual(str(execution.failure_details), 'failure_code: INFRASTRUCTURE_ERROR description: Adopt failed: cannot adopt stack with status SUSPEND_COMPLETE')
 
     def test_get_lifecycle_execution_adopt_skip_status_check(self):
         # here we generate a stack status of suspended, but will still import, becuase the skip status check will be set
@@ -556,7 +556,7 @@ class TestResourceDriverHandler(unittest.TestCase):
         self.assertEqual(execution.request_id, 'Adopt::1::request123')
         self.assertEqual(execution.status, 'FAILED')
         self.assertEqual(execution.failure_details.failure_code, 'INFRASTRUCTURE_ERROR')
-        self.assertEqual(execution.failure_details.description, 'Adopt Failed. Stack Status: ADOPT_FAILED Reason: For the test')
+        self.assertEqual(execution.failure_details.description, 'Adopt failed: cannot adopt stack with status ADOPT_FAILED')
         self.assertEqual(execution.outputs, None)
         self.assertEqual(execution.associated_topology, None)
 


### PR DESCRIPTION
To address https://github.com/IBM/openstack-vim-driver/issues/69

Original internal dev issue:
https://github.ibm.com/TNC/tnc-o-tracking/issues/222

**Change description**

The error message from Openstack driver used to be just the `stack_status_reason` field.
However, this expands that to a more user friendly message containing stack status and reason, for *Adopt* transitons that fail.
